### PR TITLE
Add gif replay on prompt:

### DIFF
--- a/src/data/tricksFilePaths.ts
+++ b/src/data/tricksFilePaths.ts
@@ -1,4 +1,4 @@
-import { TricksFilePaths } from '../types/TricksFilePaths.js';
+import { TricksFilePaths } from '../model/TricksFilePaths';
 
 const tricksBasePath = './assets/';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,15 @@
 #!/usr/bin/env node
 
 import { spawn } from 'child_process';
+import readline from 'readline';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { TAI_BINARY_EXECUTABLE_FILEPATH } from './config/constants';
-import { getArgs } from './utils/getArgs';
-
-function sleep(ms: number): Promise<void> {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-}
+import getArgs from './utils/getArgs';
+import writeTaiProcess from './utils/writeTaiProcess';
+import errorTaiProcess from './utils/errorTaiProcess';
+import removePromptText from './utils/removePromptText';
+import showRules from './utils/showRules';
 
 const main = async () => {
   await startQuiz();
@@ -29,46 +26,52 @@ const startQuiz = async () => {
     }
   ]);
   await showRules();
-  await startAscii();
+  startGif();
 };
 
-const startAscii = async (i = 2, args: string[] = []) => {
+const guessGif = async (args: string[]) => {
+  // const correctTrick = args.at(-1);
+  const answers = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'tricks',
+      message: 'Guess the trick! 🛹🤔',
+      choices: [
+        `${chalk.dim('REPLAY GIF')}`,
+        'Kickflip',
+        'Heelflip',
+        'Treflip',
+        'Lazerflip'
+      ]
+    }
+  ]);
+  console.log(answers.tricks);
+  if (answers.tricks === `${chalk.dim('REPLAY GIF')}`) {
+    startGif(args);
+  }
+  if (answers.tricks === 'Kickflip') console.log('CORRECT');
+};
+
+const startGif = (args: string[] = []) => {
   const currentArgs = args.length ? args : getArgs();
   const taiProcess = spawn(TAI_BINARY_EXECUTABLE_FILEPATH, [...currentArgs]);
 
-  // how to force stdout streams to wait - https://kisaragi-hiu.com/nodejs-cmd/
-  return new Promise(() => {
-    // Write out the data
-
-    taiProcess.stdout.on('data', (data: string) => {
-      process.stdout.write(data);
-      process.stdout.write('\n');
-      process.stdout.write('\n');
-      process.stdout.write(chalk.bgBlue('Skater stance: ...TODO!'));
-      process.stdout.write('\n');
-      process.stdout.write('\n');
-    });
-
-    taiProcess.stderr.on('data', (data) => {
-      console.error(`stderr: ${data}`);
-    });
-
-    // close stream and replay or return to quiz
-    taiProcess.on('close', async () => {
-      i > 0 ? await startAscii(i - 1, currentArgs) : startQuiz();
-    });
+  // Creating this interface prevents the user from inputting early
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
   });
-};
 
-const showRules = async () => {
-  console.log('see if we sleep...');
-  await sleep(100);
-  console.log('2nd one');
-  await sleep(100);
-  console.log('3rd one');
-  await sleep(100);
-  console.log('Leggo!');
-  await sleep(100);
+  // Write out the data
+  taiProcess.stdout.on('data', writeTaiProcess);
+  taiProcess.stderr.on('data', errorTaiProcess);
+
+  // close stream, remove the prompt text and close rl interface
+  taiProcess.on('close', async () => {
+    removePromptText();
+    rl.close(); // close the interface to prevent the too many event listeners attached bug
+    await guessGif(currentArgs);
+  });
 };
 
 main();

--- a/src/utils/errorTaiProcess.ts
+++ b/src/utils/errorTaiProcess.ts
@@ -1,0 +1,5 @@
+const errorTaiProcess = (data: string) => {
+  console.error(`stderr: ${data}`);
+};
+
+export default errorTaiProcess;

--- a/src/utils/getArgs.ts
+++ b/src/utils/getArgs.ts
@@ -1,7 +1,7 @@
 import { getRandomTrickFilePath } from './getRandomTrickFilePath.js';
 import { TAI_SCRIPT_ARGUMENTS } from '../config/constants.js';
 
-export const getArgs = () => {
+const getArgs = () => {
   return [
     TAI_SCRIPT_ARGUMENTS.dither,
     TAI_SCRIPT_ARGUMENTS.ditherScale,
@@ -14,3 +14,5 @@ export const getArgs = () => {
     getRandomTrickFilePath()
   ];
 };
+
+export default getArgs;

--- a/src/utils/getRandomTrickFilePath.ts
+++ b/src/utils/getRandomTrickFilePath.ts
@@ -1,4 +1,4 @@
-import { tricksFilePaths } from '../data/tricksFilePaths.js';
+import { tricksFilePaths } from '../data/tricksFilePaths';
 
 export const getRandomTrickFilePath = () => {
   const randomTrick =

--- a/src/utils/removePromptText.ts
+++ b/src/utils/removePromptText.ts
@@ -1,0 +1,11 @@
+import readline from 'readline';
+
+const removePromptText = () => {
+  for (let i = 0; i < 8; i++) {
+    readline.clearLine(process.stdout, 0); // Clear the line
+    readline.moveCursor(process.stdout, 0, -1); // Move cursor up one line
+  }
+  console.log('\n'); // newline to prompt inquirer properly
+};
+
+export default removePromptText;

--- a/src/utils/showRules.ts
+++ b/src/utils/showRules.ts
@@ -1,0 +1,14 @@
+import sleep from './sleep';
+
+const showRules = async () => {
+  console.log('see if we sleep...');
+  await sleep(100);
+  console.log('2nd one');
+  await sleep(100);
+  console.log('3rd one');
+  await sleep(100);
+  console.log('Leggo!');
+  await sleep(100);
+};
+
+export default showRules;

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,9 @@
+const sleep = (ms: number): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+};
+
+export default sleep;

--- a/src/utils/writeTaiProcess.ts
+++ b/src/utils/writeTaiProcess.ts
@@ -1,0 +1,22 @@
+import chalk from 'chalk';
+
+const writeTaiProcess = (data: string) => {
+  process.stdout.write(data);
+  process.stdout.write('\n');
+  process.stdout.write('\n');
+  process.stdout.write(chalk.bgBlue('Skater stance: ...TODO!\n'));
+  process.stdout.write('\n');
+  process.stdout.write(
+    `${chalk.green('?')} ${chalk.bold('Guess the trick! 🛹🤔')} ${chalk.dim(
+      '(input blocked)'
+    )}\n`
+  );
+  process.stdout.write('  Kickflip\n');
+  process.stdout.write('  Heelflip\n');
+  process.stdout.write('  Treflip\n');
+  process.stdout.write('  Lazerflip\n');
+  process.stdout.write('\n');
+  process.stdout.write(chalk.green('Playing gif...'));
+};
+
+export default writeTaiProcess;


### PR DESCRIPTION
- Move a lot of core logic into util functions
- Remove Promise wrapper and recursion from playGif
- Use readline to prevent user input during gif playing and customly clear the terminal